### PR TITLE
Made trivy scans more efficient

### DIFF
--- a/src/main/java/org/frankframework/insights/vulnerability/VulnerabilityService.java
+++ b/src/main/java/org/frankframework/insights/vulnerability/VulnerabilityService.java
@@ -34,8 +34,8 @@ public class VulnerabilityService {
     private static final long INITIAL_RETRY_DELAY_MS = 2000;
     private static final long SCAN_DELAY_MS = 5000;
     private static final int RETRY_BACKOFF_MULTIPLIER = 2;
-	private static final String TRIVY_SKIP_FILES = "**/*.properties,**/*.sh,**/*.bat,**/*.txt,**/*.java,**/*.ts,**/*.js,**/*.html,**/*.css,**/*.scss,**/*.xslt,**/*.rtf,**/*.md";
-
+    private static final String TRIVY_SKIP_FILES =
+            "**/*.properties,**/*.sh,**/*.bat,**/*.java,**/*.ts,**/*.js,**/*.html,**/*.css,**/*.scss,**/*.xslt,**/*.rtf,**/*.md";
     private static final int TRIVY_TIMEOUT_MINUTES = 30;
     private static final int JSON_OUTPUT_PREVIEW_LENGTH = 500;
     private static final int EXIT_CODE_TIMEOUT = -1;


### PR DESCRIPTION
Now i excluded a lot of file types that are not necessary for trivy vulnerability scans, which makes the scans significantly shorter