### PR TITLE
added manual apply for release dates

### DIFF
--- a/src/main/java/org/frankframework/insights/common/properties/ReleaseFixProperties.java
+++ b/src/main/java/org/frankframework/insights/common/properties/ReleaseFixProperties.java
@@ -1,0 +1,16 @@
+package org.frankframework.insights.common.properties;
+
+import java.time.OffsetDateTime;
+import java.util.HashMap;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "release-fixes")
+@Getter
+@Setter
+public class ReleaseFixProperties {
+    private HashMap<String, OffsetDateTime> dateOverrides = new HashMap<>();
+}

--- a/src/main/java/org/frankframework/insights/release/ReleaseService.java
+++ b/src/main/java/org/frankframework/insights/release/ReleaseService.java
@@ -1,370 +1,411 @@
-package org.frankframework.insights.release;
+	package org.frankframework.insights.release;
 
-import java.time.OffsetDateTime;
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
-import org.frankframework.insights.branch.Branch;
-import org.frankframework.insights.branch.BranchService;
-import org.frankframework.insights.common.entityconnection.branchpullrequest.BranchPullRequest;
-import org.frankframework.insights.common.entityconnection.releasepullrequest.ReleasePullRequest;
-import org.frankframework.insights.common.entityconnection.releasepullrequest.ReleasePullRequestRepository;
-import org.frankframework.insights.common.mapper.Mapper;
-import org.frankframework.insights.github.GitHubClient;
-import org.frankframework.insights.pullrequest.PullRequest;
-import org.springframework.stereotype.Service;
+	import java.time.OffsetDateTime;
+	import java.util.*;
+	import java.util.regex.Matcher;
+	import java.util.regex.Pattern;
+	import java.util.stream.Collectors;
+	import lombok.extern.slf4j.Slf4j;
+	import org.frankframework.insights.branch.Branch;
+	import org.frankframework.insights.branch.BranchService;
+	import org.frankframework.insights.common.entityconnection.branchpullrequest.BranchPullRequest;
+	import org.frankframework.insights.common.entityconnection.releasepullrequest.ReleasePullRequest;
+	import org.frankframework.insights.common.entityconnection.releasepullrequest.ReleasePullRequestRepository;
+	import org.frankframework.insights.common.mapper.Mapper;
+	import org.frankframework.insights.common.properties.ReleaseFixProperties;
+	import org.frankframework.insights.github.GitHubClient;
+	import org.frankframework.insights.pullrequest.PullRequest;
+	import org.springframework.stereotype.Service;
 
-/**
- * Service class for managing releases.
- * Handles the injection, mapping, and processing of GitHub releases into the database.
- */
-@Service
-@Slf4j
-public class ReleaseService {
+	/**
+	 * Service class for managing releases.
+	 * Handles the injection, mapping, and processing of GitHub releases into the database.
+	 */
+	@Service
+	@Slf4j
+	public class ReleaseService {
 
-    private final GitHubClient gitHubClient;
-    private final Mapper mapper;
-    private final ReleaseRepository releaseRepository;
-    private final BranchService branchService;
-    private final ReleasePullRequestRepository releasePullRequestRepository;
+		private final GitHubClient gitHubClient;
+		private final Mapper mapper;
+		private final ReleaseRepository releaseRepository;
+		private final BranchService branchService;
+		private final ReleasePullRequestRepository releasePullRequestRepository;
 
-    private static final String MASTER_BRANCH_NAME = "master";
-    private static final String NIGHTLY_RELEASE_NAME = "nightly";
-    private static final int FIRST_RELEASE_INDEX = 0;
-    private static final int MAJOR = 1;
-    private static final int MINOR = 2;
+		private static final String MASTER_BRANCH_NAME = "master";
+		private static final String NIGHTLY_RELEASE_NAME = "nightly";
+		private static final int FIRST_RELEASE_INDEX = 0;
+		private static final int MAJOR = 1;
+		private static final int MINOR = 2;
+		private final HashMap<String, OffsetDateTime> releaseDateOverrides;
 
-    /**
-     * Constructor for ReleaseService.
-     *
-     * @param gitHubClient Client for interacting with GitHub API.
-     * @param mapper Mapper for converting between DTOs and entities.
-     * @param releaseRepository Repository for managing Release entities.
-     * @param branchService Service for managing branches.
-     * @param releasePullRequestRepository Repository for managing ReleasePullRequest entities.
-     */
-    public ReleaseService(
-            GitHubClient gitHubClient,
-            Mapper mapper,
-            ReleaseRepository releaseRepository,
-            BranchService branchService,
-            ReleasePullRequestRepository releasePullRequestRepository) {
-        this.gitHubClient = gitHubClient;
-        this.mapper = mapper;
-        this.releaseRepository = releaseRepository;
-        this.branchService = branchService;
-        this.releasePullRequestRepository = releasePullRequestRepository;
-    }
+		/**
+		 * Constructor for ReleaseService.
+		 *
+		 * @param gitHubClient Client for interacting with GitHub API.
+		 * @param mapper Mapper for converting between DTOs and entities.
+		 * @param releaseRepository Repository for managing Release entities.
+		 * @param branchService Service for managing branches.
+		 * @param releasePullRequestRepository Repository for managing ReleasePullRequest entities.
+		 */
+		public ReleaseService(
+				GitHubClient gitHubClient,
+				Mapper mapper,
+				ReleaseRepository releaseRepository,
+				BranchService branchService,
+				ReleasePullRequestRepository releasePullRequestRepository,
+				ReleaseFixProperties releaseFixProperties) {
+			this.gitHubClient = gitHubClient;
+			this.mapper = mapper;
+			this.releaseRepository = releaseRepository;
+			this.branchService = branchService;
+			this.releasePullRequestRepository = releasePullRequestRepository;
+			this.releaseDateOverrides = releaseFixProperties.getDateOverrides();
+		}
 
-    /**
-     * Injects releases from GitHub into the database.
-     * Maps releases to branches and assigns pull requests and commits to them.
-     *
-     * @throws ReleaseInjectionException if an error occurs during the injection process.
-     */
-    public void injectReleases() throws ReleaseInjectionException {
-        try {
-            Set<ReleaseDTO> releaseDTOs = gitHubClient.getReleases();
-            List<Branch> allBranches = branchService.getAllBranches();
-            Map<String, Set<BranchPullRequest>> pullRequestsByBranch =
-                    branchService.getBranchPullRequestsByBranches(allBranches);
+		/**
+		 * Injects releases from GitHub into the database.
+		 * Maps releases to branches and assigns pull requests and commits to them.
+		 *
+		 * @throws ReleaseInjectionException if an error occurs during the injection process.
+		 */
+		public void injectReleases() throws ReleaseInjectionException {
+			try {
+				Set<ReleaseDTO> releaseDTOs = gitHubClient.getReleases();
 
-            Map<Boolean, List<ReleaseDTO>> partitionedReleases =
-                    releaseDTOs.stream().collect(Collectors.partitioningBy(ReleaseDTO::isValid));
+				Set<ReleaseDTO> manualFixedReleaseDTOs = applyManualDateFixes(releaseDTOs);
 
-            List<ReleaseDTO> validReleaseDTOs = partitionedReleases.getOrDefault(true, Collections.emptyList());
-            List<ReleaseDTO> invalidReleaseDTOs = partitionedReleases.getOrDefault(false, Collections.emptyList());
+				List<Branch> allBranches = branchService.getAllBranches();
+				Map<String, Set<BranchPullRequest>> pullRequestsByBranch =
+						branchService.getBranchPullRequestsByBranches(allBranches);
 
-            Set<Release> releases = validReleaseDTOs.stream()
-                    .map(dto -> mapToRelease(dto, allBranches))
-                    .collect(Collectors.toSet());
+				Map<Boolean, List<ReleaseDTO>> partitionedReleases =
+						manualFixedReleaseDTOs.stream().collect(Collectors.partitioningBy(ReleaseDTO::isValid));
 
-            if (releases.isEmpty()) {
-                log.info("No valid releases found.");
-                return;
-            }
+				List<ReleaseDTO> validReleaseDTOs = partitionedReleases.getOrDefault(true, Collections.emptyList());
+				List<ReleaseDTO> invalidReleaseDTOs = partitionedReleases.getOrDefault(false, Collections.emptyList());
 
-            saveAllReleases(releases);
+				Set<Release> releases = validReleaseDTOs.stream()
+						.map(dto -> mapToRelease(dto, allBranches))
+						.collect(Collectors.toSet());
 
-            Map<Branch, List<Release>> releasesByBranch = releases.stream()
-                    .filter(r -> r.getBranch() != null)
-                    .collect(Collectors.groupingBy(
-                            Release::getBranch, Collectors.collectingAndThen(Collectors.toList(), list -> list.stream()
-                                    .sorted(Comparator.comparing(Release::getPublishedAt))
-                                    .collect(Collectors.toList()))));
+				if (releases.isEmpty()) {
+					log.info("No valid releases found.");
+					return;
+				}
 
-            Map<String, OffsetDateTime> earliestBetaRCDates =
-                    buildEarliestBetaRCDatesMap(validReleaseDTOs, invalidReleaseDTOs);
+				saveAllReleases(releases);
 
-            processAndAssignPullsAndCommits(releasesByBranch, pullRequestsByBranch, earliestBetaRCDates);
-        } catch (Exception e) {
-            throw new ReleaseInjectionException("Error injecting GitHub releases.", e);
-        }
-    }
+				Map<Branch, List<Release>> releasesByBranch = releases.stream()
+						.filter(r -> r.getBranch() != null)
+						.collect(Collectors.groupingBy(
+								Release::getBranch, Collectors.collectingAndThen(Collectors.toList(), list -> list.stream()
+										.sorted(Comparator.comparing(Release::getPublishedAt))
+										.collect(Collectors.toList()))));
 
-    /**
-     * Builds a map of the earliest beta/RC dates for each valid release.
-     * This allows PRs to be assigned to the final release even if they were merged during the beta/RC period.
-     *
-     * @param validReleaseDTOs The list of valid (non-beta/RC) releases.
-     * @param invalidReleaseDTOs The list of beta/RC releases.
-     * @return A map of release tag names to their earliest beta/RC publish dates.
-     */
-    private Map<String, OffsetDateTime> buildEarliestBetaRCDatesMap(
-            List<ReleaseDTO> validReleaseDTOs, List<ReleaseDTO> invalidReleaseDTOs) {
-        Map<String, OffsetDateTime> earliestBetaRCDates = new HashMap<>();
+				Map<String, OffsetDateTime> earliestBetaRCDates =
+						buildEarliestBetaRCDatesMap(validReleaseDTOs, invalidReleaseDTOs);
 
-        for (ReleaseDTO validRelease : validReleaseDTOs) {
-            String validTagName = validRelease.tagName();
-            if (validTagName == null) continue;
+				processAndAssignPullsAndCommits(releasesByBranch, pullRequestsByBranch, earliestBetaRCDates);
+			} catch (Exception e) {
+				throw new ReleaseInjectionException("Error injecting GitHub releases.", e);
+			}
+		}
 
-            Optional<String> baseVersion = extractMajorMinor(validTagName);
-            if (baseVersion.isEmpty()) continue;
+		/**
+		 * Builds a map of the earliest beta/RC dates for each valid release.
+		 * This allows PRs to be assigned to the final release even if they were merged during the beta/RC period.
+		 *
+		 * @param validReleaseDTOs The list of valid (non-beta/RC) releases.
+		 * @param invalidReleaseDTOs The list of beta/RC releases.
+		 * @return A map of release tag names to their earliest beta/RC publish dates.
+		 */
+		private Map<String, OffsetDateTime> buildEarliestBetaRCDatesMap(
+				List<ReleaseDTO> validReleaseDTOs, List<ReleaseDTO> invalidReleaseDTOs) {
+			Map<String, OffsetDateTime> earliestBetaRCDates = new HashMap<>();
 
-            invalidReleaseDTOs.stream()
-                    .filter(invalidRelease -> invalidRelease.tagName() != null
-                            && invalidRelease.tagName().startsWith(baseVersion.get()))
-                    .map(ReleaseDTO::publishedAt)
-                    .filter(Objects::nonNull)
-                    .min(Comparator.naturalOrder())
-                    .ifPresent(earliestDate -> earliestBetaRCDates.put(validTagName, earliestDate));
-        }
+			for (ReleaseDTO validRelease : validReleaseDTOs) {
+				String validTagName = validRelease.tagName();
+				if (validTagName == null) continue;
 
-        return earliestBetaRCDates;
-    }
+				Optional<String> baseVersion = extractMajorMinor(validTagName);
+				if (baseVersion.isEmpty()) continue;
 
-    /**
-     * Maps a ReleaseDTO to a Release entity and associates it with a branch.
-     *
-     * @param dto The ReleaseDTO to map.
-     * @param branches The list of branches to match against.
-     * @return The mapped Release entity.
-     */
-    private Release mapToRelease(ReleaseDTO dto, List<Branch> branches) {
-        String releaseName = dto.name();
+				invalidReleaseDTOs.stream()
+						.filter(invalidRelease -> invalidRelease.tagName() != null
+								&& invalidRelease.tagName().startsWith(baseVersion.get()))
+						.map(ReleaseDTO::publishedAt)
+						.filter(Objects::nonNull)
+						.min(Comparator.naturalOrder())
+						.ifPresent(earliestDate -> earliestBetaRCDates.put(validTagName, earliestDate));
+			}
 
-        Optional<String> majorMinor = extractMajorMinor(releaseName);
-        Optional<Branch> matchingBranch = majorMinor.flatMap(version -> findBranchByVersion(branches, version));
+			return earliestBetaRCDates;
+		}
 
-        Branch selectedBranch = matchingBranch.orElse(null);
+		/**
+		 * Maps a ReleaseDTO to a Release entity and associates it with a branch.
+		 *
+		 * @param dto The ReleaseDTO to map.
+		 * @param branches The list of branches to match against.
+		 * @return The mapped Release entity.
+		 */
+		private Release mapToRelease(ReleaseDTO dto, List<Branch> branches) {
+			String releaseName = dto.name();
 
-        if (selectedBranch == null) {
-            selectedBranch = findMasterBranch(branches).orElse(null);
-        }
+			Optional<String> majorMinor = extractMajorMinor(releaseName);
+			Optional<Branch> matchingBranch = majorMinor.flatMap(version -> findBranchByVersion(branches, version));
 
-        Release release = mapper.toEntity(dto, Release.class);
-        release.setBranch(selectedBranch);
-        return release;
-    }
+			Branch selectedBranch = matchingBranch.orElse(null);
 
-    /**
-     * Extracts the major and minor version from a release tag name.
-     *
-     * @param tagName The tag name to extract from.
-     * @return An Optional containing the major and minor version, or empty if not found.
-     */
-    private Optional<String> extractMajorMinor(String tagName) {
-        if (tagName == null) {
-            return Optional.empty();
-        }
-        Matcher matcher = Pattern.compile("v(\\d+)\\.(\\d+)").matcher(tagName);
-        return matcher.find() ? Optional.of(matcher.group(MAJOR) + "." + matcher.group(MINOR)) : Optional.empty();
-    }
+			if (selectedBranch == null) {
+				selectedBranch = findMasterBranch(branches).orElse(null);
+			}
 
-    /**
-     * Finds a branch by matching its name with a version string.
-     *
-     * @param branches The list of branches to search.
-     * @param version The version string to match.
-     * @return An Optional containing the matching branch, or empty if not found.
-     */
-    private Optional<Branch> findBranchByVersion(List<Branch> branches, String version) {
-        return branches.stream()
-                .filter(branch -> branch.getName().contains(version))
-                .findFirst();
-    }
+			Release release = mapper.toEntity(dto, Release.class);
+			release.setBranch(selectedBranch);
+			return release;
+		}
 
-    /**
-     * Finds the master branch from a list of branches.
-     *
-     * @param branches The list of branches to search.
-     * @return An Optional containing the master branch, or empty if not found.
-     */
-    private Optional<Branch> findMasterBranch(List<Branch> branches) {
-        return branches.stream()
-                .filter(b -> MASTER_BRANCH_NAME.equalsIgnoreCase(b.getName()))
-                .findFirst();
-    }
+		/**
+		 * Extracts the major and minor version from a release tag name.
+		 *
+		 * @param tagName The tag name to extract from.
+		 * @return An Optional containing the major and minor version, or empty if not found.
+		 */
+		private Optional<String> extractMajorMinor(String tagName) {
+			if (tagName == null) {
+				return Optional.empty();
+			}
+			Matcher matcher = Pattern.compile("v(\\d+)\\.(\\d+)").matcher(tagName);
+			return matcher.find() ? Optional.of(matcher.group(MAJOR) + "." + matcher.group(MINOR)) : Optional.empty();
+		}
 
-    /**
-     * Processes and assigns pull requests and commits to releases.
-     *
-     * @param releasesByBranch A map of branches to their associated releases.
-     * @param pullRequestsByBranch A map of branch IDs to their associated pull requests.
-     * @param earliestBetaRCDates A map of release tag names to their earliest beta/RC dates.
-     */
-    private void processAndAssignPullsAndCommits(
-            Map<Branch, List<Release>> releasesByBranch,
-            Map<String, Set<BranchPullRequest>> pullRequestsByBranch,
-            Map<String, OffsetDateTime> earliestBetaRCDates) {
+		/**
+		 * Finds a branch by matching its name with a version string.
+		 *
+		 * @param branches The list of branches to search.
+		 * @param version The version string to match.
+		 * @return An Optional containing the matching branch, or empty if not found.
+		 */
+		private Optional<Branch> findBranchByVersion(List<Branch> branches, String version) {
+			return branches.stream()
+					.filter(branch -> branch.getName().contains(version))
+					.findFirst();
+		}
 
-        List<Release> masterReleases = new ArrayList<>();
-        Branch masterBranch = releasesByBranch.keySet().stream()
-                .filter(b -> MASTER_BRANCH_NAME.equalsIgnoreCase(b.getName()))
-                .findFirst()
-                .orElse(null);
+		/**
+		 * Finds the master branch from a list of branches.
+		 *
+		 * @param branches The list of branches to search.
+		 * @return An Optional containing the master branch, or empty if not found.
+		 */
+		private Optional<Branch> findMasterBranch(List<Branch> branches) {
+			return branches.stream()
+					.filter(b -> MASTER_BRANCH_NAME.equalsIgnoreCase(b.getName()))
+					.findFirst();
+		}
 
-        for (Map.Entry<Branch, List<Release>> entry : releasesByBranch.entrySet()) {
-            Branch branch = entry.getKey();
-            List<Release> releases = entry.getValue();
-            if (MASTER_BRANCH_NAME.equalsIgnoreCase(branch.getName())) continue;
+		/**
+		 * Processes and assigns pull requests and commits to releases.
+		 *
+		 * @param releasesByBranch A map of branches to their associated releases.
+		 * @param pullRequestsByBranch A map of branch IDs to their associated pull requests.
+		 * @param earliestBetaRCDates A map of release tag names to their earliest beta/RC dates.
+		 */
+		private void processAndAssignPullsAndCommits(
+				Map<Branch, List<Release>> releasesByBranch,
+				Map<String, Set<BranchPullRequest>> pullRequestsByBranch,
+				Map<String, OffsetDateTime> earliestBetaRCDates) {
 
-            Set<BranchPullRequest> prs = pullRequestsByBranch.getOrDefault(branch.getId(), Set.of());
+			List<Release> masterReleases = new ArrayList<>();
+			Branch masterBranch = releasesByBranch.keySet().stream()
+					.filter(b -> MASTER_BRANCH_NAME.equalsIgnoreCase(b.getName()))
+					.findFirst()
+					.orElse(null);
 
-            if (releases.size() == 1) {
-                masterReleases.add(releases.getFirst());
-            } else {
-                List<Release> sortedReleases = assignToReleases(releases, prs, earliestBetaRCDates);
-                masterReleases.add(sortedReleases.getFirst());
-            }
-        }
+			for (Map.Entry<Branch, List<Release>> entry : releasesByBranch.entrySet()) {
+				Branch branch = entry.getKey();
+				List<Release> releases = entry.getValue();
+				if (MASTER_BRANCH_NAME.equalsIgnoreCase(branch.getName())) continue;
 
-        if (masterBranch != null) {
-            List<Release> masterOnly = releasesByBranch.getOrDefault(masterBranch, List.of());
-            List<Release> combined = new ArrayList<>(masterReleases);
-            combined.addAll(masterOnly);
-            combined.sort(Comparator.comparing(Release::getPublishedAt));
+				Set<BranchPullRequest> prs = pullRequestsByBranch.getOrDefault(branch.getId(), Set.of());
 
-            Set<BranchPullRequest> masterPRs = pullRequestsByBranch.getOrDefault(masterBranch.getId(), Set.of());
+				if (releases.size() == 1) {
+					masterReleases.add(releases.getFirst());
+				} else {
+					List<Release> sortedReleases = assignToReleases(releases, prs, earliestBetaRCDates);
+					masterReleases.add(sortedReleases.getFirst());
+				}
+			}
 
-            assignToReleases(combined, masterPRs, earliestBetaRCDates);
-        }
-    }
+			if (masterBranch != null) {
+				List<Release> masterOnly = releasesByBranch.getOrDefault(masterBranch, List.of());
+				List<Release> combined = new ArrayList<>(masterReleases);
+				combined.addAll(masterOnly);
+				combined.sort(Comparator.comparing(Release::getPublishedAt));
 
-    /**
-     * Assigns pull requests to releases based on their publication dates.
-     * This method sorts the releases and assigns pull requests to each release based on the time window between releases.
-     * The first release in the sorted list does not get PRs assigned via this method,
-     * it serves as the starting point for the next releases time window.
-     *
-     * @param releases The list of releases to assign pull requests to.
-     * @param prs The set of branch pull requests to consider for assignment.
-     * @param earliestBetaRCDates A map of release tag names to their earliest beta/RC dates.
-     * @return A list of releases with assigned pull requests.
-     */
-    private List<Release> assignToReleases(
-            List<Release> releases, Set<BranchPullRequest> prs, Map<String, OffsetDateTime> earliestBetaRCDates) {
-        releases.sort(getReleaseSortingComparator());
+				Set<BranchPullRequest> masterPRs = pullRequestsByBranch.getOrDefault(masterBranch.getId(), Set.of());
 
-        for (int i = FIRST_RELEASE_INDEX; i < releases.size(); i++) {
-            Release current = releases.get(i);
+				assignToReleases(combined, masterPRs, earliestBetaRCDates);
+			}
+		}
 
-            // The first release in the sorted list does not get PRs assigned via this method.
-            // It serves as the starting point for the next releases time window.
-            if (i > FIRST_RELEASE_INDEX) {
-                OffsetDateTime from = releases.get(i - 1).getPublishedAt();
-                // Use the earliest beta/RC date if available, otherwise use the final release date
-                OffsetDateTime to = earliestBetaRCDates.getOrDefault(current.getTagName(), current.getPublishedAt());
-                assignPullRequests(current, prs, from, to);
-            }
-        }
-        return releases;
-    }
+		/**
+		 * Assigns pull requests to releases based on their publication dates.
+		 * This method sorts the releases and assigns pull requests to each release based on the time window between releases.
+		 * The first release in the sorted list does not get PRs assigned via this method,
+		 * it serves as the starting point for the next releases time window.
+		 *
+		 * @param releases The list of releases to assign pull requests to.
+		 * @param prs The set of branch pull requests to consider for assignment.
+		 * @param earliestBetaRCDates A map of release tag names to their earliest beta/RC dates.
+		 * @return A list of releases with assigned pull requests.
+		 */
+		private List<Release> assignToReleases(
+				List<Release> releases, Set<BranchPullRequest> prs, Map<String, OffsetDateTime> earliestBetaRCDates) {
+			releases.sort(getReleaseSortingComparator());
 
-    /**
-     * Returns a comparator for sorting releases.
-     * Nightly releases are prioritized first, followed by releases sorted by their publication date.
-     *
-     * @return A comparator for sorting releases.
-     */
-    protected Comparator<Release> getReleaseSortingComparator() {
-        return Comparator.comparing((Release release) -> release.getName() != null
-                        && release.getName().toLowerCase().contains(NIGHTLY_RELEASE_NAME))
-                .thenComparing(Release::getPublishedAt);
-    }
+			for (int i = FIRST_RELEASE_INDEX; i < releases.size(); i++) {
+				Release current = releases.get(i);
 
-    /**
-     * Assigns pull requests to a specific release based on a time range.
-     *
-     * @param release The release to assign pull requests to.
-     * @param branchPRs The set of branch pull requests to consider.
-     * @param from The start of the time range.
-     * @param to The end of the time range.
-     */
-    private void assignPullRequests(
-            Release release, Set<BranchPullRequest> branchPRs, OffsetDateTime from, OffsetDateTime to) {
-        Set<PullRequest> prs = branchPRs.stream()
-                .map(BranchPullRequest::getPullRequest)
-                .filter(p -> isInRange(p.getMergedAt(), from, to))
-                .collect(Collectors.toSet());
+				// The first release in the sorted list does not get PRs assigned via this method.
+				// It serves as the starting point for the next releases time window.
+				if (i > FIRST_RELEASE_INDEX) {
+					OffsetDateTime from = releases.get(i - 1).getPublishedAt();
+					// Use the earliest beta/RC date if available, otherwise use the final release date
+					OffsetDateTime to = earliestBetaRCDates.getOrDefault(current.getTagName(), current.getPublishedAt());
+					assignPullRequests(current, prs, from, to);
+				}
+			}
+			return releases;
+		}
 
-        if (!prs.isEmpty()) {
-            releasePullRequestRepository.saveAll(
-                    prs.stream().map(p -> new ReleasePullRequest(release, p)).collect(Collectors.toSet()));
-        }
-    }
+		/**
+		 * Returns a comparator for sorting releases.
+		 * Nightly releases are prioritized first, followed by releases sorted by their publication date.
+		 *
+		 * @return A comparator for sorting releases.
+		 */
+		protected Comparator<Release> getReleaseSortingComparator() {
+			return Comparator.comparing((Release release) -> release.getName() != null
+							&& release.getName().toLowerCase().contains(NIGHTLY_RELEASE_NAME))
+					.thenComparing(Release::getPublishedAt);
+		}
 
-    /**
-     * Checks if a date is within a specified range.
-     *
-     * @param date The date to check.
-     * @param start The start of the range.
-     * @param end The end of the range.
-     * @return True if the date is within the range, false otherwise.
-     */
-    private boolean isInRange(OffsetDateTime date, OffsetDateTime start, OffsetDateTime end) {
-        return date != null && (date.isEqual(start) || date.isAfter(start)) && date.isBefore(end);
-    }
+		/**
+		 * Assigns pull requests to a specific release based on a time range.
+		 *
+		 * @param release The release to assign pull requests to.
+		 * @param branchPRs The set of branch pull requests to consider.
+		 * @param from The start of the time range.
+		 * @param to The end of the time range.
+		 */
+		private void assignPullRequests(
+				Release release, Set<BranchPullRequest> branchPRs, OffsetDateTime from, OffsetDateTime to) {
+			Set<PullRequest> prs = branchPRs.stream()
+					.map(BranchPullRequest::getPullRequest)
+					.filter(p -> isInRange(p.getMergedAt(), from, to))
+					.collect(Collectors.toSet());
 
-    /**
-     * Saves all releases to the database.
-     *
-     * @param releases The set of releases to save.
-     */
-    private void saveAllReleases(Set<Release> releases) {
-        List<Release> savedReleases = releaseRepository.saveAll(releases);
-        log.info("Saved {} releases.", savedReleases.size());
-    }
+			if (!prs.isEmpty()) {
+				releasePullRequestRepository.saveAll(
+						prs.stream().map(p -> new ReleasePullRequest(release, p)).collect(Collectors.toSet()));
+			}
+		}
 
-    /**
-     * Retrieves all releases from the database.
-     *
-     * @return A set of ReleaseResponse DTOs representing all releases.
-     */
-    public Set<ReleaseResponse> getAllReleases() {
-        Set<ReleaseResponse> releaseResponses = releaseRepository.findAll().stream()
-                .map(r -> mapper.toDTO(r, ReleaseResponse.class))
-                .collect(Collectors.toSet());
+		/**
+		 * Checks if a date is within a specified range.
+		 *
+		 * @param date The date to check.
+		 * @param start The start of the range.
+		 * @param end The end of the range.
+		 * @return True if the date is within the range, false otherwise.
+		 */
+		private boolean isInRange(OffsetDateTime date, OffsetDateTime start, OffsetDateTime end) {
+			return date != null && (date.isEqual(start) || date.isAfter(start)) && date.isBefore(end);
+		}
 
-        log.info("Successfully fetched and mapped {} releases from the database", releaseResponses.size());
-        return releaseResponses;
-    }
+		protected Set<ReleaseDTO> applyManualDateFixes(Set<ReleaseDTO> releaseDTOs) {
+			if (this.releaseDateOverrides == null || this.releaseDateOverrides.isEmpty()) {
+				return releaseDTOs;
+			}
 
-    /**
-     * Retrieves a single release by ID from the database.
-     * @param releaseId the ID of the release to retrieve
-     * @return a ReleaseResponse DTO representing the release
-     * @throws ReleaseNotFoundException if the release does not exist
-     */
-    public ReleaseResponse getReleaseById(String releaseId) throws ReleaseNotFoundException {
-        Release release = checkIfReleaseExists(releaseId);
-        return mapper.toDTO(release, ReleaseResponse.class);
-    }
+			log.info("Checking for manual release date overrides for {} releases...", releaseDTOs.size());
 
-    /**
-     * Checks if a release with the given ID exists in the database.
-     * @param releaseId the ID of the release to check
-     * @return the Release object if it exists
-     * @throws ReleaseNotFoundException if the release does not exist
-     */
-    public Release checkIfReleaseExists(String releaseId) throws ReleaseNotFoundException {
-        Optional<Release> release = releaseRepository.findById(releaseId);
-        if (release.isEmpty()) {
-            throw new ReleaseNotFoundException("Release with ID [" + releaseId + "] not found.", null);
-        }
+			return releaseDTOs.stream()
+					.map(releaseDto -> {
+						OffsetDateTime overrideDate = this.releaseDateOverrides.get(releaseDto.tagName());
 
-        return release.get();
-    }
-}
+						if (overrideDate == null) {
+							return releaseDto;
+						}
+
+						try {
+							log.warn(
+									"Overriding publishedAt property for release [{}]: old='{}', new='{}'",
+									releaseDto.tagName(),
+									releaseDto.publishedAt(),
+									overrideDate);
+
+							return new ReleaseDTO(releaseDto.id(), releaseDto.tagName(), releaseDto.name(), overrideDate);
+						} catch (Exception e) {
+							log.error(
+									"Failed to apply override date for release [{}]. Using original date.",
+									releaseDto.tagName(),
+									e);
+							return releaseDto;
+						}
+					})
+					.collect(Collectors.toSet());
+		}
+
+		/**
+		 * Saves all releases to the database.
+		 *
+		 * @param releases The set of releases to save.
+		 */
+		private void saveAllReleases(Set<Release> releases) {
+			List<Release> savedReleases = releaseRepository.saveAll(releases);
+			log.info("Saved {} releases.", savedReleases.size());
+		}
+
+		/**
+		 * Retrieves all releases from the database.
+		 *
+		 * @return A set of ReleaseResponse DTOs representing all releases.
+		 */
+		public Set<ReleaseResponse> getAllReleases() {
+			Set<ReleaseResponse> releaseResponses = releaseRepository.findAll().stream()
+					.map(r -> mapper.toDTO(r, ReleaseResponse.class))
+					.collect(Collectors.toSet());
+
+			log.info("Successfully fetched and mapped {} releases from the database", releaseResponses.size());
+			return releaseResponses;
+		}
+
+		/**
+		 * Retrieves a single release by ID from the database.
+		 * @param releaseId the ID of the release to retrieve
+		 * @return a ReleaseResponse DTO representing the release
+		 * @throws ReleaseNotFoundException if the release does not exist
+		 */
+		public ReleaseResponse getReleaseById(String releaseId) throws ReleaseNotFoundException {
+			Release release = checkIfReleaseExists(releaseId);
+			return mapper.toDTO(release, ReleaseResponse.class);
+		}
+
+		/**
+		 * Checks if a release with the given ID exists in the database.
+		 * @param releaseId the ID of the release to check
+		 * @return the Release object if it exists
+		 * @throws ReleaseNotFoundException if the release does not exist
+		 */
+		public Release checkIfReleaseExists(String releaseId) throws ReleaseNotFoundException {
+			Optional<Release> release = releaseRepository.findById(releaseId);
+			if (release.isEmpty()) {
+				throw new ReleaseNotFoundException("Release with ID [" + releaseId + "] not found.", null);
+			}
+
+			return release.get();
+		}
+	}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,10 @@ github.includedLabels[0]=FEF2C0
 github.includedLabels[1]=D4C5F9
 github.includedLabels[2]=006B75
 
+release-fixes.date-overrides[v8.0.5]=2025-02-02T12:00:00Z
+release-fixes.date-overrides[v8.3.1]=2025-03-03T12:00:00Z
+release-fixes.date-overrides[v8.3.2]=2025-04-14T12:00:00Z
+
 release.archive.directory=/release-archive
 
 spring.web.resources.static-locations=classpath:/frontend/


### PR DESCRIPTION
<img width="792" height="622" alt="image" src="https://github.com/user-attachments/assets/870bf644-c7a4-410d-aa9e-7ed7262ae536" />


Now v8.3.1 and 8.3.2 are before the 8.3.3 again.
And the 8.0.5 is placed on the right date as well. This is already for the release timeline #286 