### PR TITLE
added skip files based on script and added cache

### DIFF
--- a/src/main/java/org/frankframework/insights/vulnerability/VulnerabilityService.java
+++ b/src/main/java/org/frankframework/insights/vulnerability/VulnerabilityService.java
@@ -46,7 +46,7 @@ public class VulnerabilityService {
 					+ "**/*.xsd,**/*.wsdl,**/*.sql,"
 					+ "**/*.jks,**/*.p12,**/*.pfx,**/*.cer,**/*.key,**/*.crt,**/*.crl,**/*.asc,"
 					+ "**/*.mjs";
-	private static final int TRIVY_TIMEOUT_MINUTES = 30;
+	private static final int TRIVY_TIMEOUT_MINUTES = 60;
     private static final int JSON_OUTPUT_PREVIEW_LENGTH = 500;
     private static final int EXIT_CODE_TIMEOUT = -1;
 


### PR DESCRIPTION
Context deadline exceeded for the last release scans.
Ive made a python script that groups the extensions in a release and calculates the size.

<br />

```
C:\Users\stijn\Documents\Python\FileExtensionCounter\venv\Scripts\python.exe C:/Users/stijn/Documents/Python/FileExtensionCounter/main.py
Voer het pad van de map in (bijv. C:\Users\Naam\Downloads): C:\release-archive\v9.4.0-20251030.042333 (nightly)
Bezig met scannen van: C:\release-archive\v9.4.0-20251030.042333 (nightly) ...

-------------------------------------------------------------------------------------
Extensie             | Aantal     | % Aantal  | Grootte         | % Grootte
-------------------------------------------------------------------------------------
.tiff                | 1          |    0.0%   | 13.39 MB        |   18.0%
.zip                 | 20         |    0.3%   | 12.66 MB        |   17.0%
.java                | 2174       |   30.5%   | 11.23 MB        |   15.1%
.pdf                 | 46         |    0.6%   | 10.62 MB        |   14.3%
.xsd                 | 257        |    3.6%   | 4.07 MB         |    5.5%
.bmp                 | 2          |    0.0%   | 3.79 MB         |    5.1%
.xml                 | 2080       |   29.2%   | 3.73 MB         |    5.0%
.msg                 | 11         |    0.2%   | 2.43 MB         |    3.3%
.js                  | 8          |    0.1%   | 1.91 MB         |    2.6%
.jar                 | 11         |    0.2%   | 1.50 MB         |    2.0%
.txt                 | 477        |    6.7%   | 1.39 MB         |    1.9%
.map                 | 4          |    0.1%   | 913.95 KB       |    1.2%
.jpeg                | 1          |    0.0%   | 881.90 KB       |    1.2%
.tif                 | 1          |    0.0%   | 791.41 KB       |    1.0%
.ppt                 | 1          |    0.0%   | 479.50 KB       |    0.6%
.ts                  | 200        |    2.8%   | 444.86 KB       |    0.6%
.json                | 248        |    3.5%   | 422.42 KB       |    0.6%
.properties          | 845        |   11.9%   | 407.21 KB       |    0.5%
.wsdl                | 35         |    0.5%   | 394.59 KB       |    0.5%
.css                 | 7          |    0.1%   | 381.33 KB       |    0.5%
.template            | 7          |    0.1%   | 315.28 KB       |    0.4%
.yaml                | 6          |    0.1%   | 291.10 KB       |    0.4%
.gif                 | 1          |    0.0%   | 256.89 KB       |    0.3%
.html                | 72         |    1.0%   | 254.81 KB       |    0.3%
.xsl                 | 109        |    1.5%   | 216.88 KB       |    0.3%
.md                  | 14         |    0.2%   | 188.89 KB       |    0.2%
.png                 | 15         |    0.2%   | 130.54 KB       |    0.2%
[Geen Extensie]      | 124        |    1.7%   | 124.51 KB       |    0.2%
.log                 | 2          |    0.0%   | 122.80 KB       |    0.2%
.crl                 | 1          |    0.0%   | 112.35 KB       |    0.1%
.svg                 | 10         |    0.1%   | 103.82 KB       |    0.1%
.jsd                 | 47         |    0.7%   | 96.82 KB        |    0.1%
.yml                 | 58         |    0.8%   | 57.42 KB        |    0.1%
.rtf                 | 1          |    0.0%   | 42.76 KB        |    0.1%
.xslt                | 19         |    0.3%   | 34.65 KB        |    0.0%
.xls                 | 1          |    0.0%   | 30.50 KB        |    0.0%
.dot                 | 1          |    0.0%   | 29.50 KB        |    0.0%
.doc                 | 1          |    0.0%   | 26.50 KB        |    0.0%
.jks                 | 8          |    0.1%   | 24.50 KB        |    0.0%
.sql                 | 8          |    0.1%   | 19.66 KB        |    0.0%
.ico                 | 2          |    0.0%   | 17.79 KB        |    0.0%
.jpg                 | 1          |    0.0%   | 15.72 KB        |    0.0%
.scss                | 63         |    0.9%   | 15.72 KB        |    0.0%
.docm                | 1          |    0.0%   | 11.54 KB        |    0.0%
.mjs                 | 1          |    0.0%   | 9.02 KB         |    0.0%
.xlsx                | 1          |    0.0%   | 8.77 KB         |    0.0%
.tsv                 | 1          |    0.0%   | 8.56 KB         |    0.0%
.jsp                 | 3          |    0.0%   | 8.21 KB         |    0.0%
.p12                 | 3          |    0.0%   | 7.45 KB         |    0.0%
.cmd                 | 1          |    0.0%   | 7.41 KB         |    0.0%
.pfx                 | 2          |    0.0%   | 6.96 KB         |    0.0%
.policy              | 1          |    0.0%   | 6.74 KB         |    0.0%
.asc                 | 4          |    0.1%   | 6.57 KB         |    0.0%
.csv                 | 7          |    0.1%   | 6.47 KB         |    0.0%
.ldif                | 2          |    0.0%   | 5.60 KB         |    0.0%
.sh                  | 8          |    0.1%   | 4.11 KB         |    0.0%
.htm                 | 1          |    0.0%   | 3.33 KB         |    0.0%
.eml                 | 1          |    0.0%   | 2.29 KB         |    0.0%
.drawio              | 1          |    0.0%   | 2.24 KB         |    0.0%
.result              | 5          |    0.1%   | 1.83 KB         |    0.0%
.cer                 | 2          |    0.0%   | 1.82 KB         |    0.0%
.key                 | 1          |    0.0%   | 1.66 KB         |    0.0%
.svg_standalone      | 1          |    0.0%   | 1.46 KB         |    0.0%
.crt                 | 1          |    0.0%   | 1.29 KB         |    0.0%
.conf                | 1          |    0.0%   | 1.24 KB         |    0.0%
.no-validate-xsl     | 2          |    0.0%   | 1.19 KB         |    0.0%
.iso-8859-1          | 2          |    0.0%   | 1.07 KB         |    0.0%
.jsonnet             | 12         |    0.2%   | 1.04 KB         |    0.0%
.example             | 1          |    0.0%   | 708.00 B        |    0.0%
.xhtml               | 2          |    0.0%   | 655.00 B        |    0.0%
.mf                  | 2          |    0.0%   | 500.00 B        |    0.0%
.webmanifest         | 1          |    0.0%   | 494.00 B        |    0.0%
.dat                 | 1          |    0.0%   | 481.00 B        |    0.0%
.additionalstringresolver | 4          |    0.1%   | 272.00 B        |    0.0%
.messagefactory      | 2          |    0.0%   | 263.00 B        |    0.0%
.changelogparser     | 2          |    0.0%   | 214.00 B        |    0.0%
.module              | 4          |    0.1%   | 187.00 B        |    0.0%
.bin                 | 5          |    0.1%   | 139.00 B        |    0.0%
.gz                  | 1          |    0.0%   | 134.00 B        |    0.0%
.logservice          | 2          |    0.0%   | 120.00 B        |    0.0%
.jsonprovider        | 3          |    0.0%   | 105.00 B        |    0.0%
.saxparserfactory    | 2          |    0.0%   | 86.00 B         |    0.0%
.xmleventfactory     | 2          |    0.0%   | 84.00 B         |    0.0%
.xmlinputfactory     | 2          |    0.0%   | 82.00 B         |    0.0%
.utf8                | 4          |    0.1%   | 79.00 B         |    0.0%
.xmloutputfactory    | 2          |    0.0%   | 76.00 B         |    0.0%
.escaped             | 1          |    0.0%   | 74.00 B         |    0.0%
.processor           | 1          |    0.0%   | 70.00 B         |    0.0%
.extensionnonsupported | 1          |    0.0%   | 67.00 B         |    0.0%
.result2             | 1          |    0.0%   | 56.00 B         |    0.0%
.result3             | 1          |    0.0%   | 50.00 B         |    0.0%
.transformerfactory  | 1          |    0.0%   | 49.00 B         |    0.0%
.logger              | 1          |    0.0%   | 41.00 B         |    0.0%
.xquery              | 1          |    0.0%   | 37.00 B         |    0.0%
.b64                 | 1          |    0.0%   | 24.00 B         |    0.0%
.1                   | 1          |    0.0%   | 0.00 B          |    0.0%
-------------------------------------------------------------------------------------
Totaal aantal bestanden: 7117
Totale grootte:          74.31 MB

Process finished with exit code 0
```

Hier uit kan je opmaken dat er veel file extenties zoals bijvorbeeld van fonts, afbeeldingen, documenten en project bestanden aan de skip files lijst kunnen toevoegen, zodat er minder gescant hoeft te worden voor cve's in onrelevante bestanden. Dit zou de trivy scan per release erg veel moeten versnellen en dus de 'context exceeded' exception moeten voorkomen.

Note: Also added cache for Trivy