### PR TITLE
removed old nightlies from branch releases when there is more then one

### DIFF
--- a/src/main/frontend/src/app/pages/release-graph/release-node.service.spec.ts
+++ b/src/main/frontend/src/app/pages/release-graph/release-node.service.spec.ts
@@ -141,6 +141,39 @@ describe('ReleaseNodeService', () => {
         expect(timeA).toBeLessThanOrEqual(timeB);
       }
     });
+
+    it('should remove older nightly releases for a branch, keeping only the latest one', () => {
+      const branchName = 'feature/test-branch';
+      const branches: Record<string, Branch> = {
+        testNightlyBranch: { id: 'b-test', name: branchName },
+      };
+
+      const nightlyReleases: Release[] = [
+        { id: 'R1-ANCHOR', name: 'v1.0.0', publishedAt: new Date('2024-10-01T10:00:00Z'), branch: branches['testNightlyBranch'], tagName: '' },
+        { id: 'N1-OLD', name: 'v1.0.1-nightly', publishedAt: new Date('2024-11-01T10:00:00Z'), branch: branches['testNightlyBranch'], tagName: '' },
+        { id: 'N2-OLDER', name: 'v1.0.2-nightly', publishedAt: new Date('2024-11-15T10:00:00Z'), branch: branches['testNightlyBranch'], tagName: '' },
+        { id: 'N3-LATEST', name: 'v1.0.3-nightly', publishedAt: new Date('2024-11-20T10:00:00Z'), branch: branches['testNightlyBranch'], tagName: '' },
+      ];
+
+      const allReleases = [...mockReleases, ...nightlyReleases];
+
+      const structuredData = service.structureReleaseData(allReleases);
+
+      const masterNodes = structuredData[0].get(MASTER_BRANCH_NAME)!;
+      const anchorNode = masterNodes.find((node) => node.id === 'R1-ANCHOR');
+
+      expect(anchorNode).toBeDefined();
+      expect(anchorNode?.originalBranch).toBe(branchName);
+
+      const subBranchMap = structuredData.find(m => m.has(branchName));
+      const subBranchNodes = subBranchMap?.get(branchName) ?? [];
+
+      expect(subBranchNodes.length).toBe(1);
+      expect(subBranchNodes[0].id).toBe('N3-LATEST');
+      expect(subBranchNodes[0].label).toContain('nightly');
+      expect(subBranchNodes.some(n => n.id === 'N1-OLD')).toBeFalse();
+      expect(subBranchNodes.some(n => n.id === 'N2-OLDER')).toBeFalse();
+    });
   });
 
   describe('calculateReleaseCoordinates', () => {


### PR DESCRIPTION
<img width="1092" height="142" alt="image" src="https://github.com/user-attachments/assets/054b9787-ce6a-4bf4-bca7-a45c73543816" />

instead of:

<img width="985" height="92" alt="image" src="https://github.com/user-attachments/assets/8e006942-2b2d-4b8a-b215-3122134ac0c3" />
