### PR TITLE
Improved link logic for links between 9.4 and 10.0 master mini nodes

### DIFF
--- a/src/main/frontend/src/app/pages/release-graph/release-link.service.ts
+++ b/src/main/frontend/src/app/pages/release-graph/release-link.service.ts
@@ -41,7 +41,7 @@ export class ReleaseLinkService {
     const allNodes = this.getAllNodesFlat(structuredGroups);
 
     return [
-      ...this.createIntraBranchLinks(masterNodes, allNodes),
+      ...this.createIntraBranchLinks(masterNodes, allNodes, skipNodes),
       ...this.createBranchLinks(structuredGroups.slice(1), masterNodes),
       ...this.createSpecialLinks(masterNodes, skipNodes),
     ];
@@ -255,13 +255,22 @@ export class ReleaseLinkService {
     return miniNode ? this.buildLink(miniNode, firstBranchNode) : null;
   }
 
-  private createIntraBranchLinks(nodes: ReleaseNode[], allNodes: ReleaseNode[] = []): ReleaseLink[] {
+  private createIntraBranchLinks(
+    nodes: ReleaseNode[],
+    allNodes: ReleaseNode[] = [],
+    skipNodes: SkipNode[] = [],
+  ): ReleaseLink[] {
     const links: ReleaseLink[] = [];
     for (let index = 0; index < nodes.length - 1; index++) {
       const source = nodes[index];
       const target = nodes[index + 1];
 
-      if (!this.isVersionGap(source, target, allNodes)) {
+      if (this.isVersionGap(source, target, allNodes)) {
+        const hasSkipNode = skipNodes.some((s) => s.sourceNodeId === source.id && s.targetNodeId === target.id);
+        if (!hasSkipNode) {
+          links.push(this.buildLink(source, target));
+        }
+      } else {
         links.push(this.buildLink(source, target));
       }
     }


### PR DESCRIPTION
Could not create links between X.Y.Z and XX.Y.Z without having a skip node in between them. Now it could also connect through mini nodes. 

Also validated with unit frontend tests

Before:
<img width="1121" height="436" alt="image" src="https://github.com/user-attachments/assets/69cb32d4-d852-4d47-832e-c1db1a60e74a" />

After:
<img width="1107" height="454" alt="image" src="https://github.com/user-attachments/assets/1778c937-fbd7-457c-85ae-dbc22d66a850" />
